### PR TITLE
Fetch citizen activity status (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ npx hardhat verify --network mainnet <address>
 
 ### Sepolia
 
-- NationCred.sol: `0xdc5dE9960aAf60CE8C773f88E7F3cC9E8dD62130`
+- NationCred.sol: `0xff5F7A95D6dd29a0543f661a148ba1B9ac554763`
 
 ### Mainnet
 

--- a/README.md
+++ b/README.md
@@ -130,4 +130,4 @@ npx hardhat verify --network mainnet <address>
 - GitHub.sol: `0xB989C0C17a3Bce679D7586d9e55B6Eab11c18687`
 - Discord.sol: `0x3415f4ffb9f89fba0ab446da4a78223e4cd73bad`
 - Discourse.sol: `0xC396F3536Cc67913bbE1e5E454c10BBA4ae8928F`
-- NationCred.sol: `0x6E6FceE39185b900821c2f67671ba8C28e342cda`
+- NationCred.sol: `0x7794F0Eb1eA812fBcdaBD559551Fb26A79720925`

--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ npx hardhat verify --network sepolia <address>
 
 ## Deploy to Main Network
 
-Set the `MAINNET_URL` in `.env`.
+Add an `.env` file, and set the variables:
+
+```
+cp .env.example .env
+```
 
 ```
 npx hardhat run scripts/deploy-<contract>.ts --network mainnet

--- a/contracts/INationCred.sol
+++ b/contracts/INationCred.sol
@@ -7,12 +7,12 @@ interface INationCred {
      *
      * @param passportID The NFT passport ID
      */
-    function isActive(uint16 passportID) external view returns (bool);
+    function isActiveID(uint16 passportID) external view returns (bool);
 
     /**
      * Returns `true` if the address belongs to an active Nation3 Citizen; `false` otherwise.
      *
      * @param citizen The address of an NFT passport's owner
      */
-    function isActiveByAddress(address citizen) external view returns (bool);
+    function isActiveAddress(address citizen) external view returns (bool);
 }

--- a/contracts/INationCred.sol
+++ b/contracts/INationCred.sol
@@ -14,5 +14,5 @@ interface INationCred {
      *
      * @param citizen The address of an NFT passport's owner
      */
-    function isActive(address citizen) external view returns (bool);
+    function isActiveByAddress(address citizen) external view returns (bool);
 }

--- a/contracts/INationCred.sol
+++ b/contracts/INationCred.sol
@@ -8,4 +8,11 @@ interface INationCred {
      * @param passportID The NFT passport ID
      */
     function isActive(uint16 passportID) external view returns (bool);
+
+    /**
+     * Returns `true` if the address belongs to an active Nation3 Citizen; `false` otherwise.
+     *
+     * @param citizen The address of an NFT passport's owner
+     */
+    function isActive(address citizen) external view returns (bool);
 }

--- a/contracts/NationCred.sol
+++ b/contracts/NationCred.sol
@@ -1,8 +1,8 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.17;
 
-import {INationCred} from "./INationCred.sol";
-import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
+import "./INationCred.sol";
+import "@openzeppelin/contracts/interfaces/IERC721.sol";
 
 /**
  * @notice Stores the passport IDs of active Nation3 citizens.
@@ -12,9 +12,9 @@ contract NationCred is INationCred {
     IERC721 public passport;
     uint16[] private passportIDs;
 
-    constructor() {
+    constructor(address passportAddress) {
         owner = address(msg.sender);
-        passport = IERC721(0x3337dac9F251d4E403D6030E18e3cfB6a2cb1333);
+        passport = IERC721(passportAddress);
     }
 
     function setOwner(address owner_) public {

--- a/contracts/NationCred.sol
+++ b/contracts/NationCred.sol
@@ -1,18 +1,20 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.17;
 
-import "./INationCred.sol";
+import {INationCred} from "./INationCred.sol";
+import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
 
 /**
  * @notice Stores the passport IDs of active Nation3 citizens.
  */
 contract NationCred is INationCred {
     address public owner;
-
+    IERC721 public passport;
     uint16[] private passportIDs;
 
     constructor() {
         owner = address(msg.sender);
+        passport = IERC721(0x3337dac9F251d4E403D6030E18e3cfB6a2cb1333);
     }
 
     function setOwner(address owner_) public {
@@ -28,6 +30,17 @@ contract NationCred is INationCred {
     function isActive(uint16 passportID) public view returns (bool) {
         for (uint16 i = 0; i < passportIDs.length; i++) {
             if (passportIDs[i] == passportID) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function isActiveByAddress(address citizen) public view returns (bool) {
+        for (uint16 i = 0; i < passportIDs.length; i++) {
+            uint256 passportID = passportIDs[i];
+            address passportOwner = passport.ownerOf(passportID);
+            if (passportOwner == citizen) {
                 return true;
             }
         }

--- a/contracts/NationCred.sol
+++ b/contracts/NationCred.sol
@@ -27,7 +27,7 @@ contract NationCred is INationCred {
         passportIDs = passportIDs_;
     }
 
-    function isActive(uint16 passportID) public view returns (bool) {
+    function isActiveID(uint16 passportID) public view returns (bool) {
         for (uint16 i = 0; i < passportIDs.length; i++) {
             if (passportIDs[i] == passportID) {
                 return true;
@@ -36,7 +36,7 @@ contract NationCred is INationCred {
         return false;
     }
 
-    function isActiveByAddress(address citizen) public view returns (bool) {
+    function isActiveAddress(address citizen) public view returns (bool) {
         for (uint16 i = 0; i < passportIDs.length; i++) {
             uint256 passportID = passportIDs[i];
             address passportOwner = passport.ownerOf(passportID);

--- a/contracts/mock/PassportMock.sol
+++ b/contracts/mock/PassportMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+
+contract PassportMock is ERC721, Ownable {
+    using Counters for Counters.Counter;
+
+    Counters.Counter private _tokenIdCounter;
+
+    constructor() ERC721("Nation3 Genesis Passport", "PASS3") {}
+
+    function safeMint(address to) public onlyOwner {
+        uint256 tokenId = _tokenIdCounter.current();
+        _tokenIdCounter.increment();
+        _safeMint(to, tokenId);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.8.0"
+        "@openzeppelin/contracts": "^4.9.3"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.2.1",
@@ -1946,9 +1946,9 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
-      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.3.tgz",
+      "integrity": "sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg=="
     },
     "node_modules/@resolver-engine/core": {
       "version": "0.3.3",
@@ -23430,9 +23430,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
-      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.3.tgz",
+      "integrity": "sha512-He3LieZ1pP2TNt5JbkPA4PNT9WC3gOTOlDcFGJW4Le4QKqwmiNJCRt44APfxMxvq7OugU/cqYuPcSBzOw38DAg=="
     },
     "@resolver-engine/core": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "typescript": "^5.0.3"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.8.0"
+    "@openzeppelin/contracts": "^4.9.3"
   }
 }

--- a/scripts/deploy-nationcred.ts
+++ b/scripts/deploy-nationcred.ts
@@ -15,7 +15,8 @@ async function main() {
 
   // We get the contract to deploy
   const NationCred = await ethers.getContractFactory("NationCred");
-  const nationCred = await NationCred.deploy();
+  const passportAddress = "0x3337dac9F251d4E403D6030E18e3cfB6a2cb1333";
+  const nationCred = await NationCred.deploy(passportAddress);
 
   await nationCred.deployed();
 

--- a/test/NationCred.ts
+++ b/test/NationCred.ts
@@ -5,25 +5,35 @@ describe("NationCred", function () {
   it("Deploy contract", async function () {
     const [owner] = await ethers.getSigners();
 
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
     const NationCred = await ethers.getContractFactory("NationCred");
-    const nationCred = await NationCred.deploy();
+    const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
     expect(await nationCred.owner()).to.equal(owner.address);
   });
 
   it("isActive - none", async function () {
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
     const NationCred = await ethers.getContractFactory("NationCred");
-    const nationCred = await NationCred.deploy();
+    const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
+
     expect(await nationCred.isActive(40)).to.equal(false);
     expect(await nationCred.isActive(42)).to.equal(false);
     expect(await nationCred.isActive(44)).to.equal(false);
   });
 
   it("isActive - setActiveCitizens called once", async function () {
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
     const NationCred = await ethers.getContractFactory("NationCred");
-    const nationCred = await NationCred.deploy();
+    const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
     await nationCred.setActiveCitizens([40, 42, 44]);
@@ -34,8 +44,11 @@ describe("NationCred", function () {
   });
 
   it("isActive - setActiveCitizens called twice", async function () {
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
     const NationCred = await ethers.getContractFactory("NationCred");
-    const nationCred = await NationCred.deploy();
+    const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
     await nationCred.setActiveCitizens([40, 42, 44]);
@@ -48,8 +61,11 @@ describe("NationCred", function () {
   });
 
   it("setActiveCitizens - set 420 passport IDs", async function () {
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
     const NationCred = await ethers.getContractFactory("NationCred");
-    const nationCred = await NationCred.deploy();
+    const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
     const passportIDs = [];
@@ -67,5 +83,84 @@ describe("NationCred", function () {
     expect(await nationCred.isActive(400)).to.equal(true);
     expect(await nationCred.isActive(419)).to.equal(true);
     expect(await nationCred.isActive(420)).to.equal(false);
+  });
+
+  it("isActiveByAddress - none", async function () {
+    const [owner] = await ethers.getSigners();
+
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
+    const NationCred = await ethers.getContractFactory("NationCred");
+    const nationCred = await NationCred.deploy(pass3.address);
+    await nationCred.deployed();
+
+    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(false);
+  });
+
+  it("isActiveByAddress - 1 passport, 1 active", async function () {
+    const [owner, otherAccount] = await ethers.getSigners();
+
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
+    const NationCred = await ethers.getContractFactory("NationCred");
+    const nationCred = await NationCred.deploy(pass3.address);
+    await nationCred.deployed();
+
+    // Mint passport #0
+    await pass3.safeMint(owner.address);
+
+    await nationCred.setActiveCitizens([0]);
+    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+      false
+    );
+  });
+
+  it("isActiveByAddress - 2 passports, 1 active", async function () {
+    const [owner, otherAccount] = await ethers.getSigners();
+
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
+    const NationCred = await ethers.getContractFactory("NationCred");
+    const nationCred = await NationCred.deploy(pass3.address);
+    await nationCred.deployed();
+
+    // Mint passport #0
+    await pass3.safeMint(owner.address);
+
+    // Mint passport #1
+    await pass3.safeMint(otherAccount.address);
+
+    await nationCred.setActiveCitizens([0]);
+    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+      false
+    );
+  });
+
+  it("isActiveByAddress - 2 passports, 2 active", async function () {
+    const [owner, otherAccount] = await ethers.getSigners();
+
+    const PASS3 = await ethers.getContractFactory("PassportMock");
+    const pass3 = await PASS3.deploy();
+
+    const NationCred = await ethers.getContractFactory("NationCred");
+    const nationCred = await NationCred.deploy(pass3.address);
+    await nationCred.deployed();
+
+    // Mint passport #0
+    await pass3.safeMint(owner.address);
+
+    // Mint passport #1
+    await pass3.safeMint(otherAccount.address);
+
+    await nationCred.setActiveCitizens([0, 1]);
+    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+      true
+    );
   });
 });

--- a/test/NationCred.ts
+++ b/test/NationCred.ts
@@ -15,7 +15,7 @@ describe("NationCred", function () {
     expect(await nationCred.owner()).to.equal(owner.address);
   });
 
-  it("isActive - none", async function () {
+  it("isActiveID - none", async function () {
     const PASS3 = await ethers.getContractFactory("PassportMock");
     const pass3 = await PASS3.deploy();
 
@@ -23,12 +23,12 @@ describe("NationCred", function () {
     const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
-    expect(await nationCred.isActive(40)).to.equal(false);
-    expect(await nationCred.isActive(42)).to.equal(false);
-    expect(await nationCred.isActive(44)).to.equal(false);
+    expect(await nationCred.isActiveID(40)).to.equal(false);
+    expect(await nationCred.isActiveID(42)).to.equal(false);
+    expect(await nationCred.isActiveID(44)).to.equal(false);
   });
 
-  it("isActive - setActiveCitizens called once", async function () {
+  it("isActiveID - setActiveCitizens called once", async function () {
     const PASS3 = await ethers.getContractFactory("PassportMock");
     const pass3 = await PASS3.deploy();
 
@@ -38,12 +38,12 @@ describe("NationCred", function () {
 
     await nationCred.setActiveCitizens([40, 42, 44]);
 
-    expect(await nationCred.isActive(40)).to.equal(true);
-    expect(await nationCred.isActive(42)).to.equal(true);
-    expect(await nationCred.isActive(44)).to.equal(true);
+    expect(await nationCred.isActiveID(40)).to.equal(true);
+    expect(await nationCred.isActiveID(42)).to.equal(true);
+    expect(await nationCred.isActiveID(44)).to.equal(true);
   });
 
-  it("isActive - setActiveCitizens called twice", async function () {
+  it("isActiveID - setActiveCitizens called twice", async function () {
     const PASS3 = await ethers.getContractFactory("PassportMock");
     const pass3 = await PASS3.deploy();
 
@@ -55,9 +55,9 @@ describe("NationCred", function () {
 
     await nationCred.setActiveCitizens([42]);
 
-    expect(await nationCred.isActive(40)).to.equal(false);
-    expect(await nationCred.isActive(42)).to.equal(true);
-    expect(await nationCred.isActive(44)).to.equal(false);
+    expect(await nationCred.isActiveID(40)).to.equal(false);
+    expect(await nationCred.isActiveID(42)).to.equal(true);
+    expect(await nationCred.isActiveID(44)).to.equal(false);
   });
 
   it("setActiveCitizens - set 420 passport IDs", async function () {
@@ -76,16 +76,16 @@ describe("NationCred", function () {
 
     await nationCred.setActiveCitizens(passportIDs);
 
-    expect(await nationCred.isActive(0)).to.equal(true);
-    expect(await nationCred.isActive(100)).to.equal(true);
-    expect(await nationCred.isActive(200)).to.equal(true);
-    expect(await nationCred.isActive(300)).to.equal(true);
-    expect(await nationCred.isActive(400)).to.equal(true);
-    expect(await nationCred.isActive(419)).to.equal(true);
-    expect(await nationCred.isActive(420)).to.equal(false);
+    expect(await nationCred.isActiveID(0)).to.equal(true);
+    expect(await nationCred.isActiveID(100)).to.equal(true);
+    expect(await nationCred.isActiveID(200)).to.equal(true);
+    expect(await nationCred.isActiveID(300)).to.equal(true);
+    expect(await nationCred.isActiveID(400)).to.equal(true);
+    expect(await nationCred.isActiveID(419)).to.equal(true);
+    expect(await nationCred.isActiveID(420)).to.equal(false);
   });
 
-  it("isActiveByAddress - none", async function () {
+  it("isActiveAddress - none", async function () {
     const [owner] = await ethers.getSigners();
 
     const PASS3 = await ethers.getContractFactory("PassportMock");
@@ -95,10 +95,10 @@ describe("NationCred", function () {
     const nationCred = await NationCred.deploy(pass3.address);
     await nationCred.deployed();
 
-    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(false);
+    expect(await nationCred.isActiveAddress(owner.address)).to.equal(false);
   });
 
-  it("isActiveByAddress - 1 passport, 1 active", async function () {
+  it("isActiveAddress - 1 passport, 1 active", async function () {
     const [owner, otherAccount] = await ethers.getSigners();
 
     const PASS3 = await ethers.getContractFactory("PassportMock");
@@ -112,13 +112,13 @@ describe("NationCred", function () {
     await pass3.safeMint(owner.address);
 
     await nationCred.setActiveCitizens([0]);
-    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
-    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+    expect(await nationCred.isActiveAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveAddress(otherAccount.address)).to.equal(
       false
     );
   });
 
-  it("isActiveByAddress - 2 passports, 1 active", async function () {
+  it("isActiveAddress - 2 passports, 1 active", async function () {
     const [owner, otherAccount] = await ethers.getSigners();
 
     const PASS3 = await ethers.getContractFactory("PassportMock");
@@ -135,13 +135,13 @@ describe("NationCred", function () {
     await pass3.safeMint(otherAccount.address);
 
     await nationCred.setActiveCitizens([0]);
-    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
-    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+    expect(await nationCred.isActiveAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveAddress(otherAccount.address)).to.equal(
       false
     );
   });
 
-  it("isActiveByAddress - 2 passports, 2 active", async function () {
+  it("isActiveAddress - 2 passports, 2 active", async function () {
     const [owner, otherAccount] = await ethers.getSigners();
 
     const PASS3 = await ethers.getContractFactory("PassportMock");
@@ -158,8 +158,8 @@ describe("NationCred", function () {
     await pass3.safeMint(otherAccount.address);
 
     await nationCred.setActiveCitizens([0, 1]);
-    expect(await nationCred.isActiveByAddress(owner.address)).to.equal(true);
-    expect(await nationCred.isActiveByAddress(otherAccount.address)).to.equal(
+    expect(await nationCred.isActiveAddress(owner.address)).to.equal(true);
+    expect(await nationCred.isActiveAddress(otherAccount.address)).to.equal(
       true
     );
   });


### PR DESCRIPTION
Add a second function that takes an `address` as a parameter instead of a passport ID.

## Dework Task

<!--- Please link to the Dework task here. -->

https://app.dework.xyz/nation3/development-guild-43499?taskId=eee0a0b1-2337-412e-ae20-b1e094768a17

## Related GitHub Issue

<!--- Please link to the GitHub issue here. -->

close #74

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

- [x] Status checks pass
- [x] Works on Sepolia
  https://sepolia.etherscan.io/address/0xff5F7A95D6dd29a0543f661a148ba1B9ac554763#code
- [x] Works on Mainnet
  https://sepolia.etherscan.io/address/0xff5F7A95D6dd29a0543f661a148ba1B9ac554763

## Are There Admin Tasks?

<!--- Please include any related admin tasks, like adding/changing environment variables in Vercel. -->
- [x] Change contract ownership to `0x69D8c80F3Af4a53d3c03A28D898b84FB60BbBfb0`
  https://etherscan.io/tx/0x324adde1cec8a2ac97f16938544f04d7c139852f24f8da11f1fadcde1a7fafd0
- [x] Update the contract address (and ABI) at https://github.com/nation3/nationcred-datasets/blob/main/nationcred/src/update-smart-contract.ts#L71
  https://github.com/nation3/nationcred-datasets/pull/103
- [ ] Update the contract address at https://github.com/nation3/citizen-directory/blob/main/src/pages/%5BpassportId%5D.tsx
- [x] Add "Active Citizen" role to Guild.xyz
  https://guild.xyz/nation3